### PR TITLE
Add paths for object and a first version of object matcher

### DIFF
--- a/MoTion-Tests/MTComposedPathTests.class.st
+++ b/MoTion-Tests/MTComposedPathTests.class.st
@@ -1,0 +1,69 @@
+Class {
+	#name : #MTComposedPathTests,
+	#superclass : #MotionPathTests,
+	#instVars : [
+		'a',
+		'b',
+		'c'
+	],
+	#category : #'MoTion-Tests-paths'
+}
+
+{ #category : #running }
+MTComposedPathTests >> setUp [
+
+	super setUp.
+
+	a := MTTestObjectA new.
+	b := MTTestObjectB new.
+	c := MTTestObjectC new.
+
+	a b: b.
+	a c: c.
+	b c: c.
+	c a: a
+]
+
+{ #category : #tests }
+MTComposedPathTests >> testComplexPathOfDifferentPaths [
+
+	| path |
+	path := MTComposedPath of: { 
+			        MTDirectChildrenPath new.
+			        (MTDirectPath of: #c).
+			        (MTDirectPath of: #a) }.
+
+	self assert: (path resolveFrom: a) equals: { a }.
+
+	"Path is b>_>a>_>_>_ should yield all the elements at the end"
+	path := MTComposedPath of: { 
+			        (MTDirectPath of: #b).
+			        MTDirectChildrenPath new.
+			        (MTDirectPath of: #a).
+			        MTDirectChildrenPath new.
+			        MTDirectChildrenPath new.
+			        MTDirectChildrenPath new }.
+
+	self assertCollection: (path resolveFrom: a) hasSameElements: { 
+			a.
+			b.
+			c }.
+
+	"Path is _>a> should yield only a"
+	path := MTComposedPath of: { 
+			        MTDirectChildrenPath new.
+			        (MTDirectPath of: #a) }.
+	self assertCollection: (path resolveFrom: a) equals: { a }
+]
+
+{ #category : #tests }
+MTComposedPathTests >> testComplexPathOfDirectPath [
+
+	| path |
+	path := MTComposedPath of: { 
+			        (MTDirectPath of: #b).
+			        (MTDirectPath of: #c).
+			        (MTDirectPath of: #a) }.
+
+	self assert: (path resolveFrom: a) equals: { a }
+]

--- a/MoTion-Tests/MTComposedPathTests.class.st
+++ b/MoTion-Tests/MTComposedPathTests.class.st
@@ -57,6 +57,28 @@ MTComposedPathTests >> testComplexPathOfDifferentPaths [
 ]
 
 { #category : #tests }
+MTComposedPathTests >> testComplexPathOfDifferentPathsCreation [
+
+	| path |
+	path := #'_>c>a' asObjectPath.
+
+	self assert: (path resolveFrom: a) equals: { a }.
+
+	"Path is b>_>a>_>_>_ should yield all the elements at the end"
+	path := #'b>_>a>_>_>_' asObjectPath.
+
+	self assertCollection: (path resolveFrom: a) hasSameElements: { 
+			a.
+			b.
+			c }.
+
+	"Path is _>a> should yield only a"
+	path := #'_>a' asObjectPath.
+
+	self assertCollection: (path resolveFrom: a) equals: { a }
+]
+
+{ #category : #tests }
 MTComposedPathTests >> testComplexPathOfDirectPath [
 
 	| path |
@@ -64,6 +86,15 @@ MTComposedPathTests >> testComplexPathOfDirectPath [
 			        (MTDirectPath of: #b).
 			        (MTDirectPath of: #c).
 			        (MTDirectPath of: #a) }.
+
+	self assert: (path resolveFrom: a) equals: { a }
+]
+
+{ #category : #tests }
+MTComposedPathTests >> testComplexPathOfDirectPathCreation [
+
+	| path |
+	path := #'b>c>a' asObjectPath.
 
 	self assert: (path resolveFrom: a) equals: { a }
 ]

--- a/MoTion-Tests/MTDirectChildrenPathTests.class.st
+++ b/MoTion-Tests/MTDirectChildrenPathTests.class.st
@@ -39,6 +39,30 @@ MTDirectChildrenPathTests >> testDirectChildrenDirectPathEquivalence [
 ]
 
 { #category : #tests }
+MTDirectChildrenPathTests >> testDirectChildrenDirectPathEquivalenceCreation [
+
+	"Tests that the result yield by a DirectChildren and a DirectPath are the same when there is only one instance variable in the start object"
+
+	| directPath |
+	directPath := MTDirectPath of: #name.
+
+	self
+		assert: (#_ asObjectPath resolveFrom: directPath)
+		equals: (#name asObjectPath resolveFrom: directPath)
+]
+
+{ #category : #tests }
+MTDirectChildrenPathTests >> testDirectChildrenPathCreation [
+	
+	| path |
+	path := #_ asObjectPath.
+	
+	self assertCollection: (path resolveFrom: a) hasSameElements: { b. c. }.
+	self assert: (path resolveFrom: b) equals: { c. }.
+	self assert: (path resolveFrom: c) equals: { a. }.
+]
+
+{ #category : #tests }
 MTDirectChildrenPathTests >> testMultipleChildrenPath [
 	
 	| path |

--- a/MoTion-Tests/MTDirectChildrenPathTests.class.st
+++ b/MoTion-Tests/MTDirectChildrenPathTests.class.st
@@ -1,0 +1,50 @@
+Class {
+	#name : #MTDirectChildrenPathTests,
+	#superclass : #MotionPathTests,
+	#instVars : [
+		'a',
+		'b',
+		'c'
+	],
+	#category : #'MoTion-Tests-paths'
+}
+
+{ #category : #tests }
+MTDirectChildrenPathTests >> setUp [
+
+	super setUp.
+
+	a := MTTestObjectA new.
+	b := MTTestObjectB new.
+	c := MTTestObjectC new.
+
+	a b: b.
+	a c: c.
+	b c: c.
+	c a: a
+]
+
+{ #category : #tests }
+MTDirectChildrenPathTests >> testDirectChildrenDirectPathEquivalence [
+
+	"Tests that the result yield by a DirectChildren and a DirectPath are the same when there is only one instance variable in the start object"
+
+	| directChildrenPath directPath |
+	directChildrenPath := MTDirectChildrenPath new.
+	directPath := MTDirectPath of: #name.
+
+	self
+		assert: (directChildrenPath resolveFrom: directPath)
+		equals: (directPath resolveFrom: directPath)
+]
+
+{ #category : #tests }
+MTDirectChildrenPathTests >> testMultipleChildrenPath [
+	
+	| path |
+	path := MTDirectChildrenPath new.
+	
+	self assertCollection: (path resolveFrom: a) hasSameElements: { b. c. }.
+	self assert: (path resolveFrom: b) equals: { c. }.
+	self assert: (path resolveFrom: c) equals: { a. }.
+]

--- a/MoTion-Tests/MTDirectPathTests.class.st
+++ b/MoTion-Tests/MTDirectPathTests.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #MTDirectPathTests,
+	#superclass : #MotionPathTests,
+	#category : #'MoTion-Tests-paths'
+}
+
+{ #category : #tests }
+MTDirectPathTests >> testDirectPathMessage [
+
+	"This test checks if the navigation of path that is an accessor is supported"
+
+	| o path |
+	path := MTDirectPath of: #class.
+	o := Object new.
+	
+	self assert: (path resolveFrom: o) equals: { Object }.
+]
+
+{ #category : #tests }
+MTDirectPathTests >> testDirectPathSlot [
+
+	"This test checks if the navigation of a simple slot"
+
+	| path |
+	path := MTDirectPath of: #name.
+
+	self assert: (path resolveFrom: path) equals: { #name }
+]

--- a/MoTion-Tests/MTDirectPathTests.class.st
+++ b/MoTion-Tests/MTDirectPathTests.class.st
@@ -5,6 +5,15 @@ Class {
 }
 
 { #category : #tests }
+MTDirectPathTests >> testDirectPathCreation [
+
+	| path |
+	path := #name asObjectPath.
+
+	self assert: (path resolveFrom: path) equals: { #name }
+]
+
+{ #category : #tests }
 MTDirectPathTests >> testDirectPathMessage [
 
 	"This test checks if the navigation of path that is an accessor is supported"

--- a/MoTion-Tests/MTRecursiveChildrenPathTests.class.st
+++ b/MoTion-Tests/MTRecursiveChildrenPathTests.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : #MTRecursiveChildrenPathTests,
+	#superclass : #MotionPathTests,
+	#instVars : [
+		'a',
+		'b',
+		'c'
+	],
+	#category : #'MoTion-Tests-paths'
+}
+
+{ #category : #running }
+MTRecursiveChildrenPathTests >> setUp [
+
+	super setUp.
+
+	a := MTTestObjectA new.
+	b := MTTestObjectB new.
+	c := MTTestObjectC new.
+
+	a b: b.
+	a c: c.
+	b c: c.
+	c a: a
+]
+
+{ #category : #running }
+MTRecursiveChildrenPathTests >> testRecursivePath [
+
+	| path |
+	path := MTRecursiveChildrenPath new.
+
+	self assertCollection: (path resolveFrom: a) hasSameElements: { 
+			a.
+			b.
+			c }
+]

--- a/MoTion-Tests/MTTestObjectA.class.st
+++ b/MoTion-Tests/MTTestObjectA.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #MTTestObjectA,
+	#superclass : #Object,
+	#instVars : [
+		'b',
+		'c'
+	],
+	#category : #'MoTion-Tests-paths'
+}
+
+{ #category : #accessing }
+MTTestObjectA >> b: aB [
+	b := aB
+]
+
+{ #category : #accessing }
+MTTestObjectA >> c: aC [
+
+	c := aC
+]

--- a/MoTion-Tests/MTTestObjectA.class.st
+++ b/MoTion-Tests/MTTestObjectA.class.st
@@ -3,9 +3,12 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'b',
-		'c'
+		'c',
+		'lint',
+		'lstring',
+		'lfloat'
 	],
-	#category : #'MoTion-Tests-paths'
+	#category : #'MoTion-Tests-class-data-tests'
 }
 
 { #category : #accessing }
@@ -17,4 +20,22 @@ MTTestObjectA >> b: aB [
 MTTestObjectA >> c: aC [
 
 	c := aC
+]
+
+{ #category : #accessing }
+MTTestObjectA >> lfloat: anObject [
+
+	lfloat := anObject
+]
+
+{ #category : #accessing }
+MTTestObjectA >> lint: anObject [
+
+	lint := anObject
+]
+
+{ #category : #accessing }
+MTTestObjectA >> lstring: anObject [
+
+	lstring := anObject
 ]

--- a/MoTion-Tests/MTTestObjectB.class.st
+++ b/MoTion-Tests/MTTestObjectB.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : #MTTestObjectB,
+	#superclass : #Object,
+	#instVars : [
+		'c'
+	],
+	#category : #'MoTion-Tests-paths'
+}
+
+{ #category : #accessing }
+MTTestObjectB >> c: aC [
+
+	c := aC
+]

--- a/MoTion-Tests/MTTestObjectB.class.st
+++ b/MoTion-Tests/MTTestObjectB.class.st
@@ -2,13 +2,34 @@ Class {
 	#name : #MTTestObjectB,
 	#superclass : #Object,
 	#instVars : [
-		'c'
+		'c',
+		'lint',
+		'lstring',
+		'lfloat'
 	],
-	#category : #'MoTion-Tests-paths'
+	#category : #'MoTion-Tests-class-data-tests'
 }
 
 { #category : #accessing }
 MTTestObjectB >> c: aC [
 
 	c := aC
+]
+
+{ #category : #accessing }
+MTTestObjectB >> lfloat: anObject [
+
+	lfloat := anObject
+]
+
+{ #category : #accessing }
+MTTestObjectB >> lint: anObject [
+
+	lint := anObject
+]
+
+{ #category : #accessing }
+MTTestObjectB >> lstring: anObject [
+
+	lstring := anObject
 ]

--- a/MoTion-Tests/MTTestObjectC.class.st
+++ b/MoTion-Tests/MTTestObjectC.class.st
@@ -2,12 +2,33 @@ Class {
 	#name : #MTTestObjectC,
 	#superclass : #Object,
 	#instVars : [
-		'a'
+		'a',
+		'lint',
+		'lstring',
+		'lfloat'
 	],
-	#category : #'MoTion-Tests-paths'
+	#category : #'MoTion-Tests-class-data-tests'
 }
 
 { #category : #accessing }
 MTTestObjectC >> a: aA [
 	a := aA
+]
+
+{ #category : #accessing }
+MTTestObjectC >> lfloat: anObject [
+
+	lfloat := anObject
+]
+
+{ #category : #accessing }
+MTTestObjectC >> lint: anObject [
+
+	lint := anObject
+]
+
+{ #category : #accessing }
+MTTestObjectC >> lstring: anObject [
+
+	lstring := anObject
 ]

--- a/MoTion-Tests/MTTestObjectC.class.st
+++ b/MoTion-Tests/MTTestObjectC.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #MTTestObjectC,
+	#superclass : #Object,
+	#instVars : [
+		'a'
+	],
+	#category : #'MoTion-Tests-paths'
+}
+
+{ #category : #accessing }
+MTTestObjectC >> a: aA [
+	a := aA
+]

--- a/MoTion-Tests/MatcherObjectTest.class.st
+++ b/MoTion-Tests/MatcherObjectTest.class.st
@@ -1,0 +1,66 @@
+Class {
+	#name : #MatcherObjectTest,
+	#superclass : #MatcherTests,
+	#instVars : [
+		'a',
+		'b',
+		'c'
+	],
+	#category : #'MoTion-Tests-matchers'
+}
+
+{ #category : #running }
+MatcherObjectTest >> setUp [
+
+	super setUp.
+
+	a := MTTestObjectA new.
+	b := MTTestObjectB new.
+	c := MTTestObjectC new.
+
+	a b: b.
+	a c: c.
+	b c: c.
+	c a: a.
+	
+	a lint: 15.
+	b lint: 42.
+	c lint: 15.
+	
+	a lstring: 'foo'.
+	b lstring: 'bar'.
+	c lstring: 'foobar'.
+]
+
+{ #category : #tests }
+MatcherObjectTest >> testDirectPathLiterals [
+
+	| matcher |
+	matcher := MatcherObject type: MTTestObjectA withProperties: {  }.
+
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MatcherObject
+		           type: MTTestObjectA
+		           withProperties:
+		           { (#lint -> (MatcherLiteralNumber of: 15)) }.
+
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MatcherObject type: MTTestObjectA withProperties: { 
+			           (#lint -> (MatcherLiteralNumber of: 15)).
+			           (#lstring -> (MatcherLiteralString of: 'foo')) }.
+
+	self assert: (matcher match: a) isMatch.
+	
+	"These test should not match"
+	matcher := MatcherObject type: MTTestObjectA withProperties: { 
+			           (#lint -> (MatcherLiteralNumber of: 15)).
+			           (#lstring -> (MatcherLiteralString of: 'foobar')) }.
+
+	self deny: (matcher match: a) isMatch
+]
+
+{ #category : #tests }
+MatcherObjectTest >> testDirectPathMatcherCreation [
+]

--- a/MoTion-Tests/MatcherObjectTest.class.st
+++ b/MoTion-Tests/MatcherObjectTest.class.st
@@ -52,15 +52,55 @@ MatcherObjectTest >> testDirectPathLiterals [
 			           (#lstring -> (MatcherLiteralString of: 'foo')) }.
 
 	self assert: (matcher match: a) isMatch.
-	
+
+
 	"These test should not match"
 	matcher := MatcherObject type: MTTestObjectA withProperties: { 
 			           (#lint -> (MatcherLiteralNumber of: 15)).
 			           (#lstring -> (MatcherLiteralString of: 'foobar')) }.
 
-	self deny: (matcher match: a) isMatch
+	self deny: (matcher match: a) isMatch.
+
+	matcher := MatcherObject
+		           type: MTTestObjectA
+		           withProperties:
+		           { (#lint -> (MatcherLiteralNumber of: 16)) }.
+
+	self deny: (matcher match: a) isMatch.
+
+	matcher := MatcherObject
+		           type: MTTestObjectA
+		           withProperties:
+		           { (#lint -> (MatcherLiteralNumber of: 16)) }.
+
+	self deny: (matcher match: b) isMatch
 ]
 
 { #category : #tests }
 MatcherObjectTest >> testDirectPathMatcherCreation [
+
+	| matcher |
+	matcher := MTTestObjectA % {  }.
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA % { (#lint -> 15) }.
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA % { 
+		           (#lint -> 15).
+		           (#lstring -> 'foo') }.
+	self assert: (matcher match: a) isMatch.
+
+
+	"These test should not match"
+	matcher := MTTestObjectA % { 
+		           (#lint -> 15).
+		           (#lstring -> 'foobar') }.
+	self deny: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA % { (#lint -> 16) }.
+	self deny: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA % { (#lint -> 16) }.
+	self deny: (matcher match: b) isMatch
 ]

--- a/MoTion-Tests/MatcherObjectTest.class.st
+++ b/MoTion-Tests/MatcherObjectTest.class.st
@@ -33,6 +33,43 @@ MatcherObjectTest >> setUp [
 ]
 
 { #category : #tests }
+MatcherObjectTest >> testDirectChildrenPathMatcherCreation [
+
+	| matcher |
+	matcher := MTTestObjectA % { (#_ -> MTTestObjectC % {  }) }.
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA
+	           % { (#'_>a' -> MTTestObjectA % { (#lint -> 15) }) }.
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA
+	           % { (#'_>_' -> MTTestObjectA % { (#lint -> 15) }) }.
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA % { 
+		           (#_ -> MTTestObjectB % {  }).
+		           (#_ -> MTTestObjectC % {  }) }.
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA % { 
+		           (#_ -> MTTestObjectB % {  }).
+		           (#_ -> MTTestObjectC % {  }).
+		           (#_ -> 15) }.
+	self assert: (matcher match: a) isMatch.
+
+
+	"These test should not match"
+	matcher := MTTestObjectA % { (#_ -> MTTestObjectA % {  }) }.
+	self deny: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA % { 
+		           (#_ -> MTTestObjectB % {  }).
+		           (#_ -> MTTestObjectA % {  }) }.
+	self deny: (matcher match: a) isMatch
+]
+
+{ #category : #tests }
 MatcherObjectTest >> testDirectPathLiterals [
 
 	| matcher |
@@ -103,4 +140,62 @@ MatcherObjectTest >> testDirectPathMatcherCreation [
 
 	matcher := MTTestObjectA % { (#lint -> 16) }.
 	self deny: (matcher match: b) isMatch
+]
+
+{ #category : #tests }
+MatcherObjectTest >> testRecursiveChildrenPathMatcherCreation [
+
+	| matcher |
+	matcher := MTTestObjectA % { (#'_*' -> MTTestObjectC % {  }) }.
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA % { (#'_*' -> MTTestObjectA % {  }) }.
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA
+	           % { (#'_*>a' -> MTTestObjectA % { (#lint -> 15) }) }.
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA
+	           % { (#'_*>_*' -> MTTestObjectA % { (#lint -> 15) }) }.
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA % { 
+		           (#'_*' -> MTTestObjectB % {  }).
+		           (#'_*' -> MTTestObjectA % { (#lint -> 15) }) }.
+	self assert: (matcher match: a) isMatch.
+
+
+	"These test should not match"
+	matcher := MTTestObjectA
+	           % { (#'_*' -> MTTestObjectA % { (#lint -> 43) }) }.
+	self deny: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA % { 
+		           (#'_*' -> MTTestObjectB % {  }).
+		           (#'_*' -> MTTestObjectA % { (#lint -> 16) }) }.
+	self deny: (matcher match: a) isMatch
+]
+
+{ #category : #tests }
+MatcherObjectTest >> testSimpleComposedPathMatcherCreation [
+
+	| matcher |
+	matcher := MTTestObjectA % { (#'b>c' -> MTTestObjectC % {  }) }.
+	self assert: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA % { 
+		           (#'c>a>b' -> MTTestObjectB % {  }).
+		           (#'b>c>lint' -> 15) }.
+	self assert: (matcher match: a) isMatch.
+
+
+	"These test should not match"
+	matcher := MTTestObjectA % { (#'b>c' -> MTTestObjectA % {  }) }.
+	self deny: (matcher match: a) isMatch.
+
+	matcher := MTTestObjectA % { 
+		           (#'c>a>b' -> MTTestObjectB % {  }).
+		           (#'b>c>lint' -> 16) }.
+	self deny: (matcher match: a) isMatch
 ]

--- a/MoTion-Tests/MatcherTests.class.st
+++ b/MoTion-Tests/MatcherTests.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MatcherTests,
 	#superclass : #TestCase,
-	#category : #'MoTion-Tests'
+	#category : #'MoTion-Tests-matchers'
 }
 
 { #category : #tests }

--- a/MoTion-Tests/MotionPathTests.class.st
+++ b/MoTion-Tests/MotionPathTests.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #MotionPathTests,
+	#superclass : #TestCase,
+	#category : #'MoTion-Tests-paths'
+}

--- a/MoTion/Association.extension.st
+++ b/MoTion/Association.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Association }
+
+{ #category : #'*MoTion' }
+Association >> % matcherProperties [
+
+	self value: self value % matcherProperties
+]

--- a/MoTion/Class.extension.st
+++ b/MoTion/Class.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #Class }
+
+{ #category : #'*MoTion' }
+Class >> % aMatcherDescription [
+
+	| properties |
+	properties := aMatcherDescription collect: [ :each | 
+		              each key asObjectPath -> each value asMatcher ].
+	^ MatcherObject type: self withProperties: properties
+]

--- a/MoTion/Class.extension.st
+++ b/MoTion/Class.extension.st
@@ -3,8 +3,5 @@ Extension { #name : #Class }
 { #category : #'*MoTion' }
 Class >> % aMatcherDescription [
 
-	| properties |
-	properties := aMatcherDescription collect: [ :each | 
-		              each key asObjectPath -> each value asMatcher ].
-	^ MatcherObject type: self withProperties: properties
+	^ MatcherObject type: self withProperties: aMatcherDescription
 ]

--- a/MoTion/MTComposedPath.class.st
+++ b/MoTion/MTComposedPath.class.st
@@ -7,10 +7,23 @@ Class {
 	#category : #'MoTion-paths'
 }
 
+{ #category : #'instance creation' }
+MTComposedPath class >> of: aCollectionOfPaths [
+
+	^ self new
+		  addAll: aCollectionOfPaths;
+		  yourself
+]
+
 { #category : #initialization }
-MTComposedPath >> addPath: aMotionPath [
+MTComposedPath >> add: aMotionPath [
 
 	paths add: aMotionPath
+]
+
+{ #category : #initialization }
+MTComposedPath >> addAll: anCollectionOfPaths [
+	paths addAll: anCollectionOfPaths 
 ]
 
 { #category : #initialization }
@@ -28,6 +41,10 @@ MTComposedPath >> resolveFrom: anObject [
 		copy := tmpObjects shallowCopy.
 		tmpObjects removeAll.
 		copy do: [ :intermediate | 
-			tmpObjects addAll: (each resolveFrom: intermediate) ] ].
-	^ tmpObjects
+			| result |
+			result := [ each resolveFrom: intermediate ]
+				          on: Exception
+				          do: [ #(  ) ].
+			tmpObjects addAll: result ] ].
+	^ tmpObjects asArray
 ]

--- a/MoTion/MTComposedPath.class.st
+++ b/MoTion/MTComposedPath.class.st
@@ -1,0 +1,33 @@
+Class {
+	#name : #MTComposedPath,
+	#superclass : #MotionPath,
+	#instVars : [
+		'paths'
+	],
+	#category : #'MoTion-paths'
+}
+
+{ #category : #initialization }
+MTComposedPath >> addPath: aMotionPath [
+
+	paths add: aMotionPath
+]
+
+{ #category : #initialization }
+MTComposedPath >> initialize [
+
+	paths := OrderedCollection new
+]
+
+{ #category : #initialization }
+MTComposedPath >> resolveFrom: anObject [
+
+	| tmpObjects copy |
+	tmpObjects := { anObject } asOrderedCollection.
+	paths do: [ :each | 
+		copy := tmpObjects shallowCopy.
+		tmpObjects removeAll.
+		copy do: [ :intermediate | 
+			tmpObjects addAll: (each resolveFrom: intermediate) ] ].
+	^ tmpObjects
+]

--- a/MoTion/MTDirectChildrenPath.class.st
+++ b/MoTion/MTDirectChildrenPath.class.st
@@ -7,11 +7,11 @@ Class {
 { #category : #resolving }
 MTDirectChildrenPath >> resolveFrom: anObject [
 
-	^ anObject class allSlots flatCollectAsSet: [ :slot | 
-		  | result |
-		  result := slot read: anObject.
-		  result ifNil: [ #(  ) ] ifNotNil: [ 
-			  (result isCollection and: [ result isString not ])
-				  ifTrue: [ result ]
-				  ifFalse: [ { result } ] ] ]
+	^ (anObject class allSlots flatCollectAsSet: [ :slot | 
+		   | result |
+		   result := slot read: anObject.
+		   result ifNil: [ #(  ) ] ifNotNil: [ 
+			   (result isCollection and: [ result isString not ])
+				   ifTrue: [ result ]
+				   ifFalse: [ { result } ] ] ]) asArray
 ]

--- a/MoTion/MTDirectChildrenPath.class.st
+++ b/MoTion/MTDirectChildrenPath.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #MTDirectChildrenPath,
+	#superclass : #MotionPath,
+	#category : #'MoTion-paths'
+}
+
+{ #category : #resolving }
+MTDirectChildrenPath >> resolveFrom: anObject [
+
+	^ anObject class allSlots flatCollectAsSet: [ :slot | 
+		  | result |
+		  result := slot read: anObject.
+		  result ifNil: [ #(  ) ] ifNotNil: [ 
+			  (result isCollection and: [ result isString not ])
+				  ifTrue: [ result ]
+				  ifFalse: [ { result } ] ] ]
+]

--- a/MoTion/MTDirectPath.class.st
+++ b/MoTion/MTDirectPath.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : #MTDirectPath,
+	#superclass : #MotionPath,
+	#category : #'MoTion-paths'
+}
+
+{ #category : #'instance creation' }
+MTDirectPath class >> of: anObjectPathString [
+
+	^ self new name: anObjectPathString asSymbol
+]
+
+{ #category : #resolving }
+MTDirectPath >> resolveFrom: anObject [
+
+	^ { ([ (anObject class slotNamed: name) read: anObject ]
+		   on: SlotNotFound
+		   do: [ anObject perform: name ]) }
+]

--- a/MoTion/MTRecursiveChildrenPath.class.st
+++ b/MoTion/MTRecursiveChildrenPath.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : #MTRecursiveChildrenPath,
+	#superclass : #MotionPath,
+	#category : #'MoTion-paths'
+}
+
+{ #category : #resolving }
+MTRecursiveChildrenPath >> initialize [
+	name := #'_*'.
+	 
+]
+
+{ #category : #resolving }
+MTRecursiveChildrenPath >> internalResolveFrom: anObject seen: seenObjects [
+
+	| directObjects |
+	directObjects := OrderedCollection new.
+	anObject class allSlots do: [ :slot | 
+		| o |
+		o := slot read: anObject.
+		o ifNotNil: [ 
+			(seenObjects includes: o) ifFalse: [ 
+				directObjects add: o.
+				seenObjects add: o ] ] ].
+
+	directObjects addAll: (directObjects flatCollect: [ :each | 
+			 self internalResolveFrom: each seen: seenObjects ]).
+
+	^ directObjects
+]
+
+{ #category : #resolving }
+MTRecursiveChildrenPath >> resolveFrom: anObject [
+
+	^ self internalResolveFrom: anObject seen: IdentitySet new
+]

--- a/MoTion/MTRecursiveChildrenPath.class.st
+++ b/MoTion/MTRecursiveChildrenPath.class.st
@@ -32,5 +32,5 @@ MTRecursiveChildrenPath >> internalResolveFrom: anObject seen: seenObjects [
 { #category : #resolving }
 MTRecursiveChildrenPath >> resolveFrom: anObject [
 
-	^ self internalResolveFrom: anObject seen: IdentitySet new
+	^ (self internalResolveFrom: anObject seen: IdentitySet new) asArray
 ]

--- a/MoTion/Matcher.class.st
+++ b/MoTion/Matcher.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'MoTion-matcher'
 }
 
-{ #category : #initialization }
+{ #category : #converting }
 Matcher >> asMatcher [
 
 	^ self
@@ -19,7 +19,7 @@ Matcher >> initialize [
 	matchingContexts := OrderedCollection new.
 ]
 
-{ #category : #accessing }
+{ #category : #matching }
 Matcher >> match: aNewValue [
 
 	| aNewContext matcherResult |
@@ -30,14 +30,14 @@ Matcher >> match: aNewValue [
 		  (self match: aNewValue withContext: aNewContext)
 ]
 
-{ #category : #accessing }
+{ #category : #matching }
 Matcher >> match: aNewValue withContext: aMatchingContext [
 	
 	self shouldBeImplemented 
 	
 ]
 
-{ #category : #accessing }
+{ #category : #matching }
 Matcher >> matchingContexts [
 
 	^ matchingContexts

--- a/MoTion/Matcher.class.st
+++ b/MoTion/Matcher.class.st
@@ -2,16 +2,21 @@ Class {
 	#name : #Matcher,
 	#superclass : #Object,
 	#instVars : [
-		'value',
 		'matchingContexts'
 	],
 	#category : #'MoTion-matcher'
 }
 
 { #category : #initialization }
+Matcher >> asMatcher [
+
+	^ self
+]
+
+{ #category : #initialization }
 Matcher >> initialize [ 
 	super initialize.
-	matchingContexts := Collection new.
+	matchingContexts := OrderedCollection new.
 ]
 
 { #category : #accessing }
@@ -36,16 +41,4 @@ Matcher >> match: aNewValue withContext: aMatchingContext [
 Matcher >> matchingContexts [
 
 	^ matchingContexts
-]
-
-{ #category : #accessing }
-Matcher >> value [
-
-	^ value
-]
-
-{ #category : #accessing }
-Matcher >> value: aValue [
-
-	value := aValue 
 ]

--- a/MoTion/MatcherLiteral.class.st
+++ b/MoTion/MatcherLiteral.class.st
@@ -1,5 +1,28 @@
 Class {
 	#name : #MatcherLiteral,
 	#superclass : #Matcher,
+	#instVars : [
+		'value'
+	],
 	#category : #'MoTion-matcher'
 }
+
+{ #category : #'instance creation' }
+MatcherLiteral class >> of: aValue [
+
+	^ self new
+		  value: aValue;
+		  yourself
+]
+
+{ #category : #accessing }
+MatcherLiteral >> value [
+
+	^ value
+]
+
+{ #category : #accessing }
+MatcherLiteral >> value: aValue [
+
+	value := aValue 
+]

--- a/MoTion/MatcherLiteralNumber.class.st
+++ b/MoTion/MatcherLiteralNumber.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'MoTion-matcher'
 }
 
-{ #category : #accessing }
+{ #category : #matching }
 MatcherLiteralNumber >> match: aNewValue withContext: aContext [
 	 		
 	
@@ -19,7 +19,7 @@ MatcherLiteralNumber >> match: aNewValue withContext: aContext [
 	^ { aContext }
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #matching }
 MatcherLiteralNumber >> matchCollectionOfNumbers: aCollectionOfLiterals withContext: aContext [
 
 
@@ -29,7 +29,8 @@ MatcherLiteralNumber >> matchCollectionOfNumbers: aCollectionOfLiterals withCont
 		 ].	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #matching }
 MatcherLiteralNumber >> matchOnlyNumber: aNumber withContext: aContext [
-	aNumber = value ifTrue: [ aContext isMatch: true ].
+
+	aContext isMatch: aNumber = value
 ]

--- a/MoTion/MatcherLiteralString.class.st
+++ b/MoTion/MatcherLiteralString.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'MoTion-matcher'
 }
 
-{ #category : #accessing }
+{ #category : #matching }
 MatcherLiteralString >> match: aNewValue withContext: aContext [
 	 		
 	 
@@ -19,27 +19,22 @@ MatcherLiteralString >> match: aNewValue withContext: aContext [
 	^ { aContext }
 ]
 
-{ #category : #accessing }
+{ #category : #matching }
 MatcherLiteralString >> matchCollectionOfStrings: aCollectionOfLiterals withContext: aContext [
- 
-		 
-		aCollectionOfLiterals do: [ :each | 
-			each isString 
-				ifTrue:[ self matchOnlyString: each withContext: aContext  ]
-				"ifFalse: [ here we have to check if it is symbol like #name .... for the customStringMatcher]"	
-		 ].	
+
+	aCollectionOfLiterals do: [ :each | 
+		each isString ifTrue: [ "ifFalse: [ here we have to check if it is symbol like #name .... for the customStringMatcher]" 
+			self matchOnlyString: each withContext: aContext ] ]
 ]
 
-{ #category : #accessing }
+{ #category : #matching }
 MatcherLiteralString >> matchOnlyString: aString withContext: aContext [
-	
+
 	"so here we are matching either fully or at least the string exist in the chain. "
-	
-	|sizeFound|
-	sizeFound :=  aString asString findString: value.
-	
-	value = aString | ((aString asString findString: value) > 0)  
-		ifTrue: [ aContext  isMatch: true ].
-	
-	 
+
+	| sizeFound |
+	sizeFound := aString asString findString: value.
+
+	aContext isMatch:
+		(value = aString or: [ (aString asString findString: value) > 0 ])
 ]

--- a/MoTion/MatcherObject.class.st
+++ b/MoTion/MatcherObject.class.st
@@ -9,8 +9,11 @@ Class {
 }
 
 { #category : #'as yet unclassified' }
-MatcherObject class >> type: aClass withProperties: properties [
+MatcherObject class >> type: aClass withProperties: aPropertiesArray [
 
+	| properties |
+	properties := aPropertiesArray collect: [ :each | 
+		              each key asObjectPath -> each value asMatcher ].
 	^ self new
 		  type: aClass;
 		  properties: properties;
@@ -22,7 +25,7 @@ MatcherObject >> initialize [
 	properties := OrderedCollection new.
 ]
 
-{ #category : #accessing }
+{ #category : #matching }
 MatcherObject >> match: anObject withContext: aContext [
 
 	| newContexts |
@@ -30,7 +33,7 @@ MatcherObject >> match: anObject withContext: aContext [
 		aContext isMatch: false.
 		^ { aContext } ].
 
-	"Here we are matching"
+	"Here we are matching" 
 	aContext isMatch: true.
 	properties ifNil: [ ^ { aContext } ].
 

--- a/MoTion/MatcherObject.class.st
+++ b/MoTion/MatcherObject.class.st
@@ -1,0 +1,61 @@
+Class {
+	#name : #MatcherObject,
+	#superclass : #Matcher,
+	#instVars : [
+		'type',
+		'properties'
+	],
+	#category : #'MoTion-matcher'
+}
+
+{ #category : #'as yet unclassified' }
+MatcherObject class >> type: aClass withProperties: properties [
+
+	^ self new
+		  type: aClass;
+		  properties: properties;
+		  yourself
+]
+
+{ #category : #accessing }
+MatcherObject >> initialize [
+	properties := OrderedCollection new.
+]
+
+{ #category : #accessing }
+MatcherObject >> match: anObject withContext: aContext [
+
+	| newContexts |
+	anObject class = type ifFalse: [ 
+		aContext isMatch: false.
+		^ { aContext } ].
+
+	"Here we are matching"
+	aContext isMatch: true.
+	properties ifNil: [ ^ { aContext } ].
+
+	newContexts := { aContext }.
+	properties do: [ :entry | 
+		| path submatcher |
+		path := entry key.
+		submatcher := entry value.
+		newContexts := (newContexts flatCollect: [ :context | 
+			                (path resolveFrom: anObject) flatCollect: [ :obj | 
+				                | copy |
+				                copy := context copy.
+				                submatcher match: obj withContext: copy ] ]) 
+			               select: [ :context | context isMatch ] ].
+	^ newContexts
+]
+
+{ #category : #accessing }
+MatcherObject >> properties: aCollectionOfProperties [
+
+	properties := aCollectionOfProperties
+]
+
+{ #category : #accessing }
+MatcherObject >> type: aClass [
+
+	type := aClass
+]

--- a/MoTion/MatchingContext.class.st
+++ b/MoTion/MatchingContext.class.st
@@ -22,6 +22,16 @@ MatchingContext >> bindings [
 	^ bindings
 ]
 
+{ #category : #accessing }
+MatchingContext >> copy [
+
+	| instance |
+	instance := self class new.
+	instance bindings addAll: self bindings.
+	instance isMatch: self isMatch.
+	^ instance
+]
+
 { #category : #initialization }
 MatchingContext >> initialize [ 
 	super initialize.

--- a/MoTion/MotionPath.class.st
+++ b/MoTion/MotionPath.class.st
@@ -8,6 +8,11 @@ Class {
 }
 
 { #category : #resolving }
+MotionPath >> asObjectPath [ 
+	^ self
+]
+
+{ #category : #resolving }
 MotionPath >> name: aName [
 	name := aName
 ]

--- a/MoTion/MotionPath.class.st
+++ b/MoTion/MotionPath.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #MotionPath,
+	#superclass : #Object,
+	#instVars : [
+		'name'
+	],
+	#category : #'MoTion-paths'
+}
+
+{ #category : #resolving }
+MotionPath >> name: aName [
+	name := aName
+]
+
+{ #category : #resolving }
+MotionPath >> resolveFrom: anObject [
+	self shouldBeImplemented 
+]

--- a/MoTion/Number.extension.st
+++ b/MoTion/Number.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Number }
+
+{ #category : #'*MoTion' }
+Number >> asMatcher [
+
+	^ MatcherLiteralNumber of: self
+]

--- a/MoTion/String.extension.st
+++ b/MoTion/String.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #String }
+
+{ #category : #'*MoTion' }
+String >> asObjectPath [
+
+	| symbol |
+	symbol := self asSymbol.
+	symbol = #_ ifTrue: [ ^ MTDirectChildrenPath new ].
+	symbol = #'_*' ifTrue: [ ^ MTRecursiveChildrenPath new ].
+	(symbol includes: $>) ifTrue: [ 
+		^ MTComposedPath of:
+			  ((symbol splitOn: '>') collect: [ :each | each asObjectPath ]) ].
+	^ MTDirectPath of: symbol
+]

--- a/MoTion/String.extension.st
+++ b/MoTion/String.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #String }
 
 { #category : #'*MoTion' }
+String >> asMatcher [
+
+	^ MatcherLiteralString of: self
+]
+
+{ #category : #'*MoTion' }
 String >> asObjectPath [
 
 	| symbol |

--- a/MoTion/Symbol.extension.st
+++ b/MoTion/Symbol.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Symbol }
+
+{ #category : #'*MoTion' }
+Symbol >> asMatcher [
+
+	^ MatcherLiteralSymbol of: self
+]


### PR DESCRIPTION
This PR provides a first implementation of paths for objects and a first version of a dedicated matcher for object.

The matcher supports direct children matching as well as recursive children object matching.