### PR TITLE
Fix NAC matcher and add a ability to deal with regex in string matchers

### DIFF
--- a/MoTion-Tests/MatcherTests.class.st
+++ b/MoTion-Tests/MatcherTests.class.st
@@ -70,7 +70,7 @@ MatcherTests >> testMatcherStringPartial [
 	
 	| myMatcher |
 	myMatcher := MatcherLiteralString new.
-	myMatcher value: 'Hello'.
+	myMatcher value: 'Hello.*'.
 	 
 	self assert: (myMatcher match: 'Hello World') isMatch.
 	self deny: (myMatcher match: 'Hi Mr.') isMatch 

--- a/MoTion/Matcher.class.st
+++ b/MoTion/Matcher.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : #Matcher,
 	#superclass : #Object,
-	#instVars : [
-		'matchingContexts'
-	],
 	#category : #'MoTion-matcher'
 }
 
@@ -37,12 +34,6 @@ Matcher >> collectBindings: bindings for: anObject [
 { #category : #matching }
 Matcher >> debugMe [
 	^ MatcherDebug of: self
-]
-
-{ #category : #initialization }
-Matcher >> initialize [ 
-	super initialize.
-	matchingContexts := OrderedCollection new.
 ]
 
 { #category : #matching }
@@ -90,13 +81,6 @@ Matcher >> match: aNewValue withContext: aMatchingContext [
 	
 	self shouldBeImplemented 
 	
-]
-
-{ #category : #matching }
-Matcher >> matchingContexts [
-
-	"returns the list of matchingContexts only."
-	^ matchingContexts
 ]
 
 { #category : #initialization }

--- a/MoTion/MatcherCollection.class.st
+++ b/MoTion/MatcherCollection.class.st
@@ -86,7 +86,7 @@ contexts := matchContexts collect: [ :each | each copy ].
 			aMotionCursor forward ifTrue: [
 				(aMotionCursor patternCursor > aMotionCursor patternSize) ifTrue: [ 
 					(aMotionCursor subjectCursor > aMotionCursor subjectSize) ifTrue: [ 		 
-							"!! here a full combination of matches is found."	 
+							"!! here a full combination of matches is found."	
 							^ true.
 						].
 					"here we have cannot go forward anymore as patternCursor reached the max but without matching all subjects, which is why we decrement patternCursor"
@@ -174,7 +174,6 @@ contexts := matchContexts collect: [ :each | each copy ].
 												
 			] 
 			ifTrue: [ | start min max length subjects |
-				
 				"Set values of start min max ... before start using them"	
 				aMotionCursor forward ifTrue:[
 					"start = subjectCursor "
@@ -236,7 +235,6 @@ contexts := matchContexts collect: [ :each | each copy ].
 					 
 				].				
 			].
-		
 		^ false.
 
 ]

--- a/MoTion/MatcherDebug.class.st
+++ b/MoTion/MatcherDebug.class.st
@@ -13,6 +13,11 @@ MatcherDebug class >> of: aMatcher [
 ]
 
 { #category : #matching }
+MatcherDebug >> isCollectionMatcher [ 
+	^ innerMatcher isCollectionMatcher 
+]
+
+{ #category : #matching }
 MatcherDebug >> match: anObject withContext: aMatchingContext [
 	self halt.
 	^ innerMatcher match: anObject withContext: aMatchingContext

--- a/MoTion/MatcherLiteralString.class.st
+++ b/MoTion/MatcherLiteralString.class.st
@@ -10,7 +10,10 @@ MatcherLiteralString >> match: aNewValue withContext: aContext [
 	"a String matcher can either fully match a String, can be found inside another String or can be available in a list of Strings. So the first condition is used to match only one String fully or if exists in a long string, while the second one is checking if the String exists in a collection of given Strings. If a match is found, aContext isMatch is returned as True. " 
 	
 	aNewValue isString 
-		ifTrue: [ self matchOnlyString: aNewValue withContext: aContext]
+		ifTrue: [ 
+			"self matchOnlyString: aNewValue withContext: aContext"
+			^ self regexMatch: aNewValue withContext: aContext.
+		]
 		ifFalse: [
 				aNewValue isCollection & (aNewValue isNotNil) 
 					ifTrue: [self matchCollectionOfStrings: aNewValue withContext: aContext] 
@@ -39,4 +42,11 @@ MatcherLiteralString >> matchOnlyString: aString withContext: aContext [
 
 	aContext isMatch:
 		(value = aString or: [ (aString asString findString: value) > 0 ])
+]
+
+{ #category : #matching }
+MatcherLiteralString >> regexMatch: aNewValue withContext: aContext [
+
+	aContext isMatch: (aNewValue matchesRegex: value).
+	^ { aContext }
 ]

--- a/MoTion/MatcherObject.class.st
+++ b/MoTion/MatcherObject.class.st
@@ -62,8 +62,7 @@ MatcherObject >> match: anObject withContext: aContext [
 					                copy := context copy.
 					                submatcher
 						                match: (path resolveFrom: anObject)
-						                withContext: copy ] ]) select: [ :context | 
-			               context isMatch ] ].
+						                withContext: copy ] ]) select: #isMatch ].
 	^ newContexts
 ]
 

--- a/MoTion/Object.extension.st
+++ b/MoTion/Object.extension.st
@@ -7,5 +7,5 @@ Object >> <=> aMatcherObject [
 
 { #category : #'*MoTion' }
 Object >> <~=> aMatcherObject [
-	^  self -> (MatcherNAC of: aMatcherObject)
+	^  self -> (MatcherNAC of: aMatcherObject asMatcher)
 ]


### PR DESCRIPTION
This also allows to use differently BlockMatchers (to build matchers depending on results of other matchers). 

For example:

```smalltalk
matcher := CompiledMethod % { 
	#'methodClass>name' <=> #'@name'. 
	#selector <=> [:name | 'test', name, '.*' ].
} as: #method.

(CompiledMethod allInstances collect: [ :each | matcher match: each ]) select: #isMatch
```
This matcher selects all the methods that starts with `test` followed by the name of the class they are installed in (on my image, there is 2 results)